### PR TITLE
Add support for Apple Silicon

### DIFF
--- a/src/LocalPhpSecurityCheckerInstaller.php
+++ b/src/LocalPhpSecurityCheckerInstaller.php
@@ -30,6 +30,7 @@ class LocalPhpSecurityCheckerInstaller implements PluginInterface, EventSubscrib
         'x86_64' => 'amd64',
         'amd64' => 'amd64',
         'arm' => 'arm64',
+        'arm64' => 'arm64',
     ];
 
     /**


### PR DESCRIPTION
Apple Silicon reports its architecture as arm64